### PR TITLE
fix: allow moving game entries to list end in GameRepositoryImpl

### DIFF
--- a/shared/src/commonMain/kotlin/com/app/ralaunch/shared/data/repository/GameRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/app/ralaunch/shared/data/repository/GameRepositoryImpl.kt
@@ -78,9 +78,11 @@ class GameRepositoryImpl(
 
     override suspend fun moveGame(fromPosition: Int, toPosition: Int) {
         val games = _gamesFlow.value.toMutableList()
-        if (fromPosition in games.indices && toPosition in games.indices) {
+        if (fromPosition in games.indices) {
             val game = games.removeAt(fromPosition)
-            games.add(toPosition, game)
+            // 支持将项目移动到列表末尾，同时对越界位置做保护
+            val targetPosition = toPosition.coerceIn(0, games.size)
+            games.add(targetPosition, game)
             updateAndSave(games)
         }
     }


### PR DESCRIPTION
### Motivation
- Fix a bug in list reordering where moving a game item to the last position could silently fail because the original `moveGame` required `toPosition` to be in the old list indices.

### Description
- Update `shared/src/commonMain/kotlin/com/app/ralaunch/shared/data/repository/GameRepositoryImpl.kt` so `moveGame` only validates `fromPosition`, removes the item, computes `targetPosition = toPosition.coerceIn(0, games.size)`, inserts the item at `targetPosition`, and then calls `updateAndSave(games)` to persist the change.

### Testing
- Attempted to run `./gradlew :shared:compileKotlinMetadata --no-daemon`, but the build failed in this environment with `Unsupported class file major version 69`, so compilation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f3a9d148c832699d155cab56bd78e)