### PR TITLE
feat: 添加 GitHub Actions APK 自动编译工作流

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -42,11 +42,8 @@ jobs:
             "cmake;${ANDROID_CMAKE_VERSION}"
           yes | sdkmanager --licenses || true
 
-      # 生成Debug签名密钥（如果仓库没有配置的话）
       - name: Generate Debug Keystore
         run: |
-          # 生成标准Android Debug密钥
-          # 密码: android，别名: androiddebugkey，组织: Android Debug
           keytool -genkey -v \
             -keystore debug.keystore \
             -alias androiddebugkey \
@@ -56,38 +53,34 @@ jobs:
             -storepass android \
             -keypass android \
             -dname "CN=Android Debug, O=Android, C=US"
-          
           echo "Debug密钥生成完成"
-          keytool -list -keystore debug.keystore -storepass android
 
       - name: Build APK
         run: |
           chmod +x ./gradlew
           ./gradlew clean
-          # 构建Release版本（优化过），但用Debug签名
           ./gradlew assembleRelease --no-daemon
 
       - name: Sign APK with Debug Key
         run: |
-          APK=$(find app/build/outputs/apk/release -name "*.apk" | head -1)
-          SIGNED_APK="${APK%.apk}-signed.apk"
+          UNSIGNED_APK=$(find app/build/outputs/apk/release -name "*-unsigned.apk" | head -1)
+          SIGNED_APK="${UNSIGNED_APK%-unsigned.apk}-signed.apk"
           
-          # 使用apksigner签名（推荐，支持v1/v2/v3签名方案）
+          # 签名
           ${ANDROID_SDK_ROOT}/build-tools/${ANDROID_BUILD_TOOLS}/apksigner sign \
             --ks debug.keystore \
             --ks-key-alias androiddebugkey \
             --ks-pass pass:android \
             --key-pass pass:android \
             --out "${SIGNED_APK}" \
-            "${APK}"
+            "${UNSIGNED_APK}"
           
-          # 验证签名
-          echo "=== 签名信息 ==="
+          # 验证签名并清理未签名文件
           ${ANDROID_SDK_ROOT}/build-tools/${ANDROID_BUILD_TOOLS}/apksigner verify -v "${SIGNED_APK}"
+          rm -f "${UNSIGNED_APK}"
           
-          # 替换原文件
-          mv "${SIGNED_APK}" "${APK}"
-          echo "APK已签名: ${APK}"
+          echo "APK已签名: ${SIGNED_APK}"
+          ls -la app/build/outputs/apk/release/
 
       - name: Upload Signed APK
         uses: actions/upload-artifact@v4
@@ -95,6 +88,7 @@ jobs:
           name: RAL-DebugSigned-${{ github.run_id }}
           path: app/build/outputs/apk/release/*-signed.apk
           retention-days: 30
+          if-no-files-found: error  # 找不到文件时让构建失败，避免静默错误
 
       - run: |
           echo "✅ 构建完成（Debug签名）"


### PR DESCRIPTION
## 功能介绍
新增 GitHub Actions 工作流，实现代码推送后自动编译 Android APK 并上传产物。

## 主要特性
- 🚀 **自动触发**：Push 到 main/master 分支自动编译
- 🎨 **手动触发**：支持 workflow_dispatch 手动运行
- 🔐 **自动签名**：使用 Debug Keystore 自动签名（支持 v1/v2/v3 签名方案）
- 📦 **产物上传**：自动上传至 Actions Artifacts，保留 30 天
- 🛠️ **最新工具链**：Android SDK 36 + NDK r28 + Java 21

## 技术细节
| 配置项 | 版本 |
|--------|------|
| OS | ubuntu-latest |
| Java | 21 (Temurin) |
| Android SDK | API 36 |
| Build Tools | 36.0.0 |
| NDK | 28.0.13004108 |
| CMake | 3.22.1 |

## 使用方式
1. 推送代码到 `main` 或 `master` 分支，自动触发构建
2. 或进入 Actions → Build RAL APK (Debug Signed) → Run workflow 手动触发
3. 构建完成后在运行详情页 Artifact 区域下载 APK

## 验证清单
- [x] Workflow 文件语法检查通过
- [x] 本地测试编译流程完整
- [x] 签名验证（apksigner verify）通过
- [x] Artifact 上传路径配置正确

## 新增文件
- `.github/workflows/build-apk.yml`

## 注意事项
- 使用 Debug 签名密钥（仅用于测试/开发）
- Release 发布建议使用正式密钥重新签名
- 产物保留 30 天后自动清理