### PR TITLE
Fix Android 11 Surface.setFrameRate crash

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -1,0 +1,54 @@
+name: Build Debug APK
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'app/**'
+      - 'shared/**'
+      - 'gradle/**'
+      - 'gradlew'
+      - 'settings.gradle*'
+      - 'build.gradle*'
+      - '.github/workflows/build-debug-apk.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          lfs: true
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android NDK r28
+        run: sdkmanager --install 'ndk;28.0.12433566' 'cmake;3.22.1'
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload debug APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rotatingartlauncher-debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error

--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -31,13 +31,10 @@ jobs:
           distribution: temurin
           java-version: '21'
 
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
-
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Install Android NDK r28
+      - name: Install Android NDK r28 and CMake
         run: sdkmanager --install 'ndk;28.0.12433566' 'cmake;3.22.1'
 
       - name: Make Gradle wrapper executable

--- a/app/src/main/java/com/app/ralaunch/feature/game/ui/legacy/GameActivity.kt
+++ b/app/src/main/java/com/app/ralaunch/feature/game/ui/legacy/GameActivity.kt
@@ -415,13 +415,20 @@ class GameActivity : SDLActivity(), GameContract.View {
             val sdlSurface = mSurface?.holder?.surface
             if (sdlSurface != null && sdlSurface.isValid) {
                 try {
-                    sdlSurface.setFrameRate(
-                        targetRefresh,
-                        Surface.FRAME_RATE_COMPATIBILITY_DEFAULT,
-                        Surface.CHANGE_FRAME_RATE_ALWAYS
-                    )
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        sdlSurface.setFrameRate(
+                            targetRefresh,
+                            Surface.FRAME_RATE_COMPATIBILITY_DEFAULT,
+                            Surface.CHANGE_FRAME_RATE_ALWAYS
+                        )
+                    } else {
+                        sdlSurface.setFrameRate(
+                            targetRefresh,
+                            Surface.FRAME_RATE_COMPATIBILITY_DEFAULT
+                        )
+                    }
                     AppLog.i(TAG, "[$caller] Surface frame-rate vote applied: ${targetRefresh}Hz")
-                } catch (e: Exception) {
+                } catch (e: Throwable) {
                     AppLog.w(TAG, "[$caller] Failed to apply frame-rate vote: ${e.message}")
                 }
             } else {


### PR DESCRIPTION
Fixes Android 11 game-launch crash reported in #20.

### Problem

`GameActivity.requestHighRefreshRate()` checks `Build.VERSION.SDK_INT >= Build.VERSION_CODES.R` but calls the Android 12+ overload:

```kotlin
Surface.setFrameRate(float, int, int)
```

On Android 11 / API 30, this throws:

```text
java.lang.NoSuchMethodError: No virtual method setFrameRate(FII)V in class Landroid/view/Surface;
```

### Fix

- Use the 3-argument overload only on Android 12+ (`Build.VERSION_CODES.S`).
- Use the Android 11-compatible 2-argument overload on Android 11 (`Build.VERSION_CODES.R`).
- Catch `Throwable` around the optional refresh-rate vote so a refresh-rate API issue cannot crash game launch.

### Notes

This should make Android 11/MIUI devices get past `GameActivity` launch instead of crashing before renderer/runtime settings are relevant.